### PR TITLE
Modificaciones y mejoras al docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ to run with docker compose, create file .env with
 docker-compose up
 ```
 
+to install/unistall modules you can use:
+
+```bash
+docker-compose run api npm install <package>
+```
+
 # [How to contribute](https://github.com/faztcommunity/docs/blob/dev/contribute.md)
 
 ## Contributors
@@ -82,3 +88,4 @@ docker-compose up
 - CejasClaudio [About me](https://github.com/CejasClaudioA)
 - Paolinsky (Paolo Torregroza) [About me](https://github.com/PaoloTorregroza)
 - Keneth Sandoval [GitHub](https://github.com/keneth3000)
+- Jkauze (Jesus Kauze) [About me](https://github.com/jkauze)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '3000:3000'
     volumes:
       - .:/usr/src/app
+      - /usr/src/app/node_modules
     links:
       - mongo
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   api:
     image: node
     container_name: faztapi
+    depends_on:
+      - mongo
     build: .
     ports:
       - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: faztapi
     depends_on:
       - mongo
+      - redis
     build: .
     ports:
       - '3000:3000'


### PR DESCRIPTION
**Mejorando practicas para los volumenes:**
Se separa del volumen de docker la carpeta node_modules, de manera que le dejamos el trabajo al container () de mantenerlo.
Con esto evitamos el doble **npm install** para quienes usen el proyecto con docker, (_el primer npm install lo realizaba el dockerfile y el segundo tenia que ser ejecutado por el usuario en su maquina_). Se agrego instrucción en el Readme de como trabajar con docker-compose y npm install

**Definiendo dependencias de servicios:**
Se agrego de igual forma la propiedad **depends_on** en el docker-compose para definir el orden de ejecución de los contenedores (el servicio **api** depende los servicios  **mongo** y **redis**)